### PR TITLE
set_registers method

### DIFF
--- a/hll.c
+++ b/hll.c
@@ -234,6 +234,7 @@ HyperLogLog_registers(HyperLogLog *self)
     return registers;
 }
 
+
 /* Sets register at index to rank. */
 static PyObject *
 HyperLogLog_set_register(HyperLogLog *self, PyObject * args)
@@ -280,6 +281,28 @@ static PyObject *
 HyperLogLog_seed(HyperLogLog* self)
 {
     return Py_BuildValue("i", self->seed);
+}
+
+/* set all registers */
+static PyObject *
+HyperLogLog_set_registers(HyperLogLog *self, PyObject *args)
+{
+    PyByteArrayObject *regs;
+
+    if (!PyArg_ParseTuple(args, "O", &regs))
+        return NULL;
+
+    char* registers;
+    registers = PyByteArray_AsString((PyObject*) regs);
+    
+    int i;
+    for (i = 0; i < self->size; i++) {
+            self->registers[i] = registers[i];
+    }
+
+    Py_INCREF(Py_None);
+    return Py_None;
+    
 }
 
 /* Support for pickling, called when HyperLogLog is de-serialized. */
@@ -332,6 +355,9 @@ static PyMethodDef HyperLogLog_methods[] = {
     },
     {"seed", (PyCFunction)HyperLogLog_seed, METH_NOARGS, 
      "Get the seed used in the Murmur3 hash."
+    },
+    {"set_registers", (PyCFunction)HyperLogLog_set_registers, METH_VARARGS, 
+     "Set the registers with a bytearray." 
     },
     {"set_register", (PyCFunction)HyperLogLog_set_register, METH_VARARGS, 
      "Set the register at a zero-based index to the specified rank." 


### PR DESCRIPTION
method to set all the registers at once. Calling set_register in a loop from python was too slow. I do not set size, assuming the new registers has the same size as the current one.