### PR TITLE
Fix compiler error on Windows

### DIFF
--- a/hll.c
+++ b/hll.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <Python.h>
 #include "structmember.h"
 #include "hll.h"

--- a/hll.h
+++ b/hll.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 uint32_t leadingZeroCount(uint32_t x);
 
 uint32_t ones(uint32_t x);


### PR DESCRIPTION
Need to include stdint.h so compiler can handle uint32_t on Windows.
