### PR TITLE
Add text of MIT license and metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2014 Joshua Andersen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ using a Murmur3 hash [2] for python 2.7.x or python 3.x.
 ![Build Status](https://travis-ci.org/ascv/HyperLogLog.png?branch=master)
 (https://travis-ci.org/ascv/HyperLogLog)
 
-v 1.2.6
+v 1.2.7
 
 Setup
 =====
@@ -88,7 +88,7 @@ Gets the number of registers.
 License
 =======
 
-This software is released under the [MIT License](https://gist.github.com/ascv/5123769).
+This software is released under the [MIT License](LICENSE).
 
 References
 ==========

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 
 setup(
     name='HLL',
-    version='1.2.6',
+    version='1.2.7',
     description='HyperLogLog implementation in C for python.',
     author='Joshua Andersen',
     author_email='anderj0@uw.edu',
@@ -13,6 +13,7 @@ setup(
     ],
     headers=['src/hll.h', 'lib/murmur3.h'],
     keywords=['HyperLogLog', 'Hyper LogLog', 'LogLog', 'cardinality', 'counting', 'sketch'],
+    license='MIT',
     long_description=\
 """
 The HyperLogLog algorithm [1] is a space efficient method to estimate the


### PR DESCRIPTION
Thanks for releasing this package! Was doing a check of the licenses of dependencies of one of my projects today and [`pip-licenses`](https://pypi.org/project/pip-licenses/) reported HLL as 'UNKNOWN'.

As stated in the README this project is released under the MIT license but this is not exposed in a manner that the Python package index can see.

This branch adds the license text and includes the setup.py license argument.