### PR TITLE
Fix memory leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ using a Murmur3 hash [2] for python 2.7.x or python 3.x.
 ![Build Status](https://travis-ci.org/ascv/HyperLogLog.png?branch=master)
 (https://travis-ci.org/ascv/HyperLogLog)
 
-v 1.2.7
+v 1.2.8
 
 Setup
 =====

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 
 setup(
     name='HLL',
-    version='1.2.7',
+    version='1.2.8',
     description='HyperLogLog implementation in C for python.',
     author='Joshua Andersen',
     author_email='anderj0@uw.edu',

--- a/src/hll.c
+++ b/src/hll.c
@@ -251,7 +251,7 @@ HyperLogLog_reduce(HyperLogLog *self)
 
     free(arr);
 
-    return Py_BuildValue("(OOO)", Py_TYPE(self), args, registers);
+    return Py_BuildValue("(ONN)", Py_TYPE(self), args, registers);
 }
 
 /* Gets a copy of the registers as a bytesarray. */

--- a/src/hll.c
+++ b/src/hll.c
@@ -175,9 +175,9 @@ HyperLogLog_murmur3_hash(HyperLogLog *self, PyObject *args)
         return NULL;
     }
 
-    uint32_t *hash = (uint32_t *) malloc(sizeof(uint32_t));
-    MurmurHash3_x86_32((void *) data, dataLength, self->seed, (void *) hash);
-    return Py_BuildValue("i", *hash);
+    uint32_t hash;
+    MurmurHash3_x86_32((void *) data, dataLength, self->seed, (void *) &hash);
+    return Py_BuildValue("i", hash);
 }
 
 /* Merges another HyperLogLog into the current HyperLogLog. The registers of
@@ -248,6 +248,9 @@ HyperLogLog_reduce(HyperLogLog *self)
 
     PyObject *args = Py_BuildValue("(ii)", self->k, self->seed);
     PyObject *registers = Py_BuildValue("s#", arr, self->size);
+
+    free(arr);
+
     return Py_BuildValue("(OOO)", Py_TYPE(self), args, registers);
 }
 


### PR DESCRIPTION
The documentation for the `Py_BuildValue` method states:

> When memory buffers are passed as parameters to supply data to build objects, as for the `s` and `s#` formats, the required data is copied. Buffers provided by the caller are never referenced by the objects created by `Py_BuildValue()`. In other words, if your code invokes `malloc()` and passes the allocated memory to `Py_BuildValue()`, your code is responsible for calling `free()` for that memory once `Py_BuildValue()` returns.