### PR TITLE
Add type, bounds, and value checking to set_registers()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
   - "2.7"
 install:
   - python setup.py sdist
-  - pip install dist/HLL-1.2.8.tar.gz
+  - pip install dist/HLL-1.3.0.tar.gz
 script:
   - python test.py

--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ Sets the register at *index* to *value*. Indexing is zero-based.
 
     set_registers(registers)
 
-Sets the registers to *registers*. Extra or missing registers in *registers* are
-ignored. This method can be used to restore a HyperLogLog from a bytearray.
+Sets the registers to *registers*. Expects a bytearray or bytes type.
 
     size()
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 
 setup(
     name='HLL',
-    version='1.2.8',
+    version='1.3.0',
     description='HyperLogLog implementation in C for python.',
     author='Joshua Andersen',
     author_email='anderj0@uw.edu',

--- a/test.py
+++ b/test.py
@@ -214,12 +214,33 @@ class TestRegisterFunctions(unittest.TestCase):
     def test_bytesarray_has_correct_length(self):
         self.assertTrue(len(self.hll.registers()) == pow(2, self.k))
 
-    def test_set_registers(self):
+    def test_set_registers_with_bytearray(self):
         expected = bytearray(randint(0, 16) for x in range(32))
         self.hll.set_registers(expected)
 
         registers=self.hll.registers()
         self.assertEqual(expected, registers)
+
+    def test_set_registers_with_bytes(self):
+        expected = bytearray(randint(0, 16) for x in range(32))
+        self.hll.set_registers(bytes(expected))
+
+        registers=self.hll.registers()
+        self.assertEqual(expected, registers)
+
+    @unittest.skipIf(sys.version_info[0] >= 3, 'TypeError raised in Python 3')
+    def test_set_registers_raises_value_error(self):
+        expected = bytearray(range(10, 42))
+
+        with self.assertRaises(ValueError):
+            self.hll.set_registers(bytes(expected))
+
+    @unittest.skipIf(sys.version_info[0] < 3, 'ValueError raised in Python 2')
+    def test_set_registers_raises_type_error(self):
+        expected = bytearray(range(10, 42))
+
+        with self.assertRaises(ValueError):
+            self.hll.set_registers(bytes(expected))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
```
import HLL

h = HLL.HyperLogLog(3)
b = bytearray(8)
b[0] = 1
b[7] = 1

print('Using bytearray')
h.set_registers(b)
print(map(int, h.registers()))

print('Using bytes')
b[1] = 1
b[6] = 1
h.set_registers(bytes(b))
print(map(int, h.registers()))

# 2.7.x ValueError, 3.x TypeError 
h.set_registers('aaaaaaaa')
```