### PR TITLE
Use Py_ssize_t instead of uint32_t.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
   - "2.7"
 install:
   - python setup.py sdist
-  - pip install dist/HLL-1.3.0.tar.gz
+  - pip install dist/HLL-1.3.1.tar.gz
 script:
   - python test.py

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 
 setup(
     name='HLL',
-    version='1.3.0',
+    version='1.3.1',
     description='HyperLogLog implementation in C for python.',
     author='Joshua Andersen',
     author_email='anderj0@uw.edu',

--- a/src/hll.c
+++ b/src/hll.c
@@ -1,3 +1,5 @@
+#define PY_SSIZE_T_CLEAN
+
 #include <math.h>
 #include <Python.h>
 #include <stdbool.h>
@@ -71,7 +73,7 @@ static PyObject *
 HyperLogLog_add(HyperLogLog *self, PyObject *args)
 {
     const char *data;
-    const uint32_t dataLength;
+    const Py_ssize_t dataLength;
 
     if (!PyArg_ParseTuple(args, "s#", &data, &dataLength))
         return NULL;
@@ -168,7 +170,7 @@ static PyObject *
 HyperLogLog_murmur3_hash(HyperLogLog *self, PyObject *args)
 {
     const char *data;
-    const uint32_t dataLength;
+    const Py_ssize_t dataLength;
 
     if (!PyArg_ParseTuple(args, "s#", &data, &dataLength)) {
         return NULL;


### PR DESCRIPTION
Do this to avoid warnings from python starting with
python3.8.
See note at:
https://docs.python.org/3.8/c-api/arg.html.