### PR TITLE
Fix bug in deserializing dense sketches

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Build Status](https://travis-ci.org/ascv/HyperLogLog.png?branch=master)
 (https://travis-ci.org/ascv/HyperLogLog)
 
-v 2.0.1
+v 2.0.3
 
 Overview
 ========

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 
 setup(
     name='HLL',
-    version='2.0.2',
+    version='2.0.3',
     description='HyperLogLog implementation in C for python.',
     author='Joshua Andersen',
     author_email='josh.h.andersen@gmail.com',

--- a/src/hll.c
+++ b/src/hll.c
@@ -1,5 +1,5 @@
 #define PY_SSIZE_T_CLEAN
-#define HLL_VERSION "2.0.2"
+#define HLL_VERSION "2.0.3"
 
 #include <math.h>
 #include <Python.h>
@@ -981,7 +981,7 @@ static PyObject* HyperLogLog_set_state(HyperLogLog* self, PyObject* state)
         for (uint64_t i = 65 + 7; i < dumpSize; i++) {
             valPtr = PyList_GetItem(dump, i);
             val = PyLong_AsUnsignedLong(valPtr);
-            setDenseRegister(i-63, (uint8_t)val, self->registers);
+            setDenseRegister(i - 72, (uint8_t)val, self->registers);
         }
     }
 

--- a/test.py
+++ b/test.py
@@ -183,6 +183,12 @@ class TestPickling(unittest.TestCase):
             hll2 = pickle.loads(pickle.dumps(hll))
             self.assertEqual(hll._histogram(), hll2._histogram())
 
+    def test_dense_pickled_registers(self):
+        for hll in self.dense_hlls:
+            hll2 = pickle.loads(pickle.dumps(hll))
+            for i in range(hll.size()):
+                self.assertEqual(hll.get_register(i), hll2.get_register(i))
+
     def test_dense_pickled_size(self):
          for hll in self.dense_hlls:
             hll2 = pickle.loads(pickle.dumps(hll))
@@ -202,6 +208,12 @@ class TestPickling(unittest.TestCase):
         for hll in self.sparse_hlls:
             hll2 = pickle.loads(pickle.dumps(hll))
             self.assertEqual(hll._histogram(), hll2._histogram())
+
+    def test_sparse_pickled_registers(self):
+        for hll in self.sparse_hlls:
+            hll2 = pickle.loads(pickle.dumps(hll))
+            for i in range(hll.size()):
+                self.assertEqual(hll.get_register(i), hll2.get_register(i))
 
     def test_sparse_pickled_size(self):
          for hll in self.sparse_hlls:


### PR DESCRIPTION
This fixes #44 by populating the correct registers during deserialization into a dense representation.

Also adds unit tests to check registers after deserialization and increments version number for deserialization fix.